### PR TITLE
Add optional numpy parallel compiler, fix some syntax and add Python 3.11 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
           tar zxf zeroc-ice-3.6.5.tar.gz
           patch -p0 < zeroc-ice-feedstock/recipe/osx.patch
           patch -p0 < 0001-numpy-parallel-compiler-and-syntax.patch
+          patch -p0 < 0002-python-311-support.patch
           cd zeroc-ice-3.6.5
           export MACOSX_DEPLOYMENT_TARGET=11.0
           python setup.py build -j 3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,14 +20,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Prepare build environment
+        run: |
+          pip install wheel twine numpy
       - name: Build wheel
         run: |
-          pip install wheel twine
           curl -J -O -L 'https://pypi.io/packages/source/z/zeroc-ice/zeroc-ice-3.6.5.tar.gz'
           tar zxf zeroc-ice-3.6.5.tar.gz
           patch -p0 < zeroc-ice-feedstock/recipe/osx.patch
           patch -p0 < 0001-numpy-parallel-compiler-and-syntax.patch
           cd zeroc-ice-3.6.5
+          python setup.py build -j 3
           python setup.py bdist_wheel
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     runs-on: macos-latest
     steps:
       - name: Checkout repository and submodules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Python
@@ -33,7 +33,7 @@ jobs:
           python setup.py build -j 3
           python setup.py bdist_wheel
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: artifacts
           path: zeroc-ice-3.6.5/dist/*.whl
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts from build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: List artifacts
         run: ls -R
       - name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           patch -p0 < zeroc-ice-feedstock/recipe/osx.patch
           patch -p0 < 0001-numpy-parallel-compiler-and-syntax.patch
           cd zeroc-ice-3.6.5
-          export MACOSX_DEPLOYMENT_TARGET=10.13
+          export MACOSX_DEPLOYMENT_TARGET=11.0
           python setup.py build -j 3
           python setup.py bdist_wheel
       - name: Upload artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           curl -J -O -L 'https://pypi.io/packages/source/z/zeroc-ice/zeroc-ice-3.6.5.tar.gz'
           tar zxf zeroc-ice-3.6.5.tar.gz
           patch -p0 < zeroc-ice-feedstock/recipe/osx.patch
+          patch -p0 < 0001-numpy-parallel-compiler-and-syntax.patch
           cd zeroc-ice-3.6.5
           python setup.py bdist_wheel
       - name: Upload artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
           patch -p0 < zeroc-ice-feedstock/recipe/osx.patch
           patch -p0 < 0001-numpy-parallel-compiler-and-syntax.patch
           cd zeroc-ice-3.6.5
+          export MACOSX_DEPLOYMENT_TARGET=10.13
           python setup.py build -j 3
           python setup.py bdist_wheel
       - name: Upload artifacts

--- a/0001-numpy-parallel-compiler-and-syntax.patch
+++ b/0001-numpy-parallel-compiler-and-syntax.patch
@@ -1,0 +1,26 @@
+--- zeroc-ice-3.6.5.orig/setup.py	2019-07-31 21:49:38.000000000 +0200
++++ zeroc-ice-3.6.5/setup.py	2023-10-11 15:19:06.069872372 +0200
+@@ -4,6 +4,14 @@
+ #
+ # **********************************************************************
+ 
++try:
++    from numpy.distutils.ccompiler import CCompiler_compile
++    import distutils.ccompiler
++    distutils.ccompiler.CCompiler.compile = CCompiler_compile
++    print("numpy found, parallel compile is available")
++except ImportError:
++    print("numpy not found, parallel compile not available")
++
+ # Always prefer setuptools over distutils
+ try:
+     from setuptools import setup
+@@ -108,7 +116,7 @@
+         libraries = ["IceSSL", "Ice", "Slice", "IceUtil"]
+     else:
+         libraries=['ssl', 'crypto', 'bz2', 'rt']
+-        if platform is not 'freebsd':
++        if platform != 'freebsd':
+             libraries.append('dl')
+ 
+     def filterName(path):

--- a/0002-python-311-support.patch
+++ b/0002-python-311-support.patch
@@ -1,0 +1,33 @@
+Only in zeroc-ice-3.6.5: setup.py.orig
+diff --color -ur zeroc-ice-3.6.5.orig/src/Slice.cpp zeroc-ice-3.6.5/src/Slice.cpp
+--- zeroc-ice-3.6.5.orig/src/Slice.cpp	2019-07-31 21:49:38.000000000 +0200
++++ zeroc-ice-3.6.5/src/Slice.cpp	2023-10-12 10:52:07.029069937 +0200
+@@ -17,12 +17,6 @@
+ #include <Slice/Util.h>
+ #include <IceUtil/Options.h>
+ 
+-//
+-// Python headers needed for PyEval_EvalCode.
+-//
+-#include <compile.h>
+-#include <eval.h>
+-
+ using namespace std;
+ using namespace IcePy;
+ using namespace Slice;
+diff --color -ur zeroc-ice-3.6.5.orig/src/Util.cpp zeroc-ice-3.6.5/src/Util.cpp
+--- zeroc-ice-3.6.5.orig/src/Util.cpp	2019-07-31 21:49:38.000000000 +0200
++++ zeroc-ice-3.6.5/src/Util.cpp	2023-10-12 10:49:15.033366926 +0200
+@@ -214,7 +214,12 @@
+     //
+     // Get name of current function.
+     //
++    // Use PyEval_GetFrame with Pyhthon >= 3.11
++#if PY_VERSION_HEX >= 0x030B0000
++    PyFrameObject *f = PyEval_GetFrame();
++#else
+     PyFrameObject *f = PyThreadState_GET()->frame;
++#endif
+     PyObjectHandle code = PyObject_GetAttrString(reinterpret_cast<PyObject*>(f), STRCAST("f_code"));
+     assert(code.get());
+     PyObjectHandle func = PyObject_GetAttrString(code.get(), STRCAST("co_name"));


### PR DESCRIPTION
Adds the numpy parallel compiler as an option. This is deprecated upstream [^1] but is a very nice and quick way to accelerate these builds. Python 3.11 support has also been added. See also:

* zeroc-ice/ice#1393
* zeroc-ice/ice#1394
* ome/omero-py#360

[^1]: https://numpy.org/devdocs/reference/distutils_status_migration.html