### PR TITLE
Fix wheel platform tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Prepare build environment
         run: |
-          pip install wheel twine numpy
+          pip install wheel>=0.40.0 twine numpy
       - name: Build wheel
         run: |
           curl -J -O -L 'https://pypi.io/packages/source/z/zeroc-ice/zeroc-ice-3.6.5.tar.gz'
@@ -33,6 +33,19 @@ jobs:
           export MACOSX_DEPLOYMENT_TARGET=11.0
           python setup.py build -j 3
           python setup.py bdist_wheel
+      - name: Fix wheel platform tag
+        run: |
+          # If the installed Python is, for example, `unixersal2`, the default
+          # platform tag always be `universal2` even if the build is just
+          # x86_64 like it is here.  We need to fix the wheels we produce so
+          # that we don't advertise platform tags that are not actually
+          # supported.
+          #
+          # See:
+          #  * https://github.com/pypa/wheel/issues/406
+          python -m wheel tags \
+            --platform-tag=macosx_11_0_x86_64 \
+            --remove zeroc-ice-3.6.5/dist/*.whl
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
 If the installed Python is, for example, `universal2`, the default
 platform tag always be `universal2` even if the build is just
x86_64 like it is here.  We need to fix the wheels we produce so
that we don't advertise platform tags that are not actually
supported.

See:
* https://github.com/pypa/packaging/issues/882