### PR TITLE
Only build Ice Python x86_64 wheel packages for Python 3.8 & 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9']
     runs-on: macos-latest
     steps:
       - name: Checkout repository and submodules


### PR DESCRIPTION
Python 3.10 & 3.11 versions are available under the macos-13-xlarge environments allowing to build universal2 wheel packages compatible with both x86_64 and arm64 architectures